### PR TITLE
Don't send unsolicited emails either

### DIFF
--- a/channel-policies.md
+++ b/channel-policies.md
@@ -15,7 +15,7 @@ Here you can find postings for development jobs in the Triangle area
 
 Rules:
 
-1. Do not send unsolicited DMs to members about job openings
+1. Do not send unsolicited DMs or emails to members about job openings
 1. Posts from recruiters looking for candidates to fill a position go in [#jobs-recruiters](https://triangledevs.slack.com/messages/jobs-recruiters/)
 1. Posts directly from companies looking to hire or devs looking for a position go in [#jobs](https://triangledevs.slack.com/messages/job)
 1. Posts looking for short-term contractors or freelancers go in [#freelance-gigs](https://triangledevs.slack.com/messages/freelance-gigs/)


### PR DESCRIPTION
I've been getting spam from recruiters after posting in #jobs - I'd like to have the ability to refer them back to the channel policy directing them to not do that.