### PR TITLE
Include @admins slack user group in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Documentation, Info, and Code of Conduct for the [Triangle Devs Slack Channel](h
 
 [Admins Group Email](mailto:trianglerb-organizers@googlegroups.com)
 
-These people are labeled as "Admins" on this slack. They are organizers in the NC Triangle area as well as individuals that help us enforce our [Code of Conduct][conduct]:
+These people are labeled as "Admins" on this slack and can be notified with `@admins` in slack. They are organizers in the NC Triangle area as well as individuals that help us enforce our [Code of Conduct][conduct]:
 
 * [Brandon Mathis](https://triangledevs.slack.com/messages/@brandonmathis/)
 * [TJ Stankus](https://triangledevs.slack.com/messages/@tjstankus/)

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -34,6 +34,7 @@ If someone makes you or anyone else feel unsafe or unwelcome, please report it a
 
 * Feel free to DM any of the admins at any time
 * [Emailing the admin team](mailto:triangledevs-slack@googlegroups.com)
+* If harrassment is occurring in a public channel, you can notify all admins with `@admins`
 
 When taking a report, our staff will work to ensure you are safe and cannot be overheard. You won't be asked to confront anyone and we won't tell anyone who you are.
 


### PR DESCRIPTION
Slack workspaces now support [user groups](https://slack.com/help/articles/212906697-Create-a-user-group). This PR updates the docs assuming an `@admins` user group exists for the workspace. 

Feel free to reject if this isn't something you're interested in managing!